### PR TITLE
Fix Next.js global CSS import

### DIFF
--- a/mes-universal-table/MESUniversalTable.tsx
+++ b/mes-universal-table/MESUniversalTable.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import FileUpload from './helpers/FileUpload'
 import SignaturePad from './helpers/SignaturePad'
-import './mes-universal-table.css'
 import {
   ColumnDef,
   flexRender,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,6 @@
 import type { AppProps } from 'next/app'
 import '../styles/globals.css'
+import '../mes-universal-table/mes-universal-table.css'
 
 export default function App({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />


### PR DESCRIPTION
## Summary
- remove CSS import from `MESUniversalTable`
- load table CSS globally from `_app.tsx`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_685fdad2abfc832ba4f9612ac67d8b37