### PR TITLE
Fix: Resolve button inactivity and improve column removal

### DIFF
--- a/mes-universal-table/MESUniversalTable.tsx
+++ b/mes-universal-table/MESUniversalTable.tsx
@@ -299,14 +299,13 @@ export default function MESUniversalTable({
     setRows(r => r.map(row => ({ ...row, [id]: '' })))
   }
 
-  const removeColumn = (index: number) => {
-    const col = cols[index]
-    setCols(c => c.filter((_, i) => i !== index))
-    setRows(r => r.map(row => {
-      const { [col.field_id]: _, ...rest } = row
-      return rest
-    }))
-  }
+  const removeColumnByFieldId = (fieldIdToRemove: string) => {
+    setCols(currentCols => currentCols.filter(c => c.field_id !== fieldIdToRemove));
+    setRows(currentRows => currentRows.map(row => {
+      const { [fieldIdToRemove]: _, ...rest } = row;
+      return rest;
+    }));
+  };
 
   const mergeRows = () => {
     if (rows.length < 2) return
@@ -429,9 +428,21 @@ export default function MESUniversalTable({
                     style={{ backgroundColor: style.header_color, color: style.header_font_color }}
                   >
                     {cell.label}
-                    {i === headerRows.length - 1 && !cell.children && (
-                      <button onClick={() => removeColumn(idx)} className="ml-1 text-xs text-red-500">x</button>
-                    )}
+                    {
+                      // Add remove button for leaf header cells in the last row of the header
+                      i === headerRows.length - 1 &&
+                      !cell.children &&
+                      cell.columns && cell.columns.length === 1 && // Ensure it maps to a single column
+                      (
+                        <button
+                          onClick={() => removeColumnByFieldId(cell.columns[0])}
+                          className="ml-1 text-xs text-red-500 hover:text-red-700"
+                          title={`Remove ${cell.label} column`}
+                        >
+                          x
+                        </button>
+                      )
+                    }
                   </th>
                 )
               })}

--- a/mes-universal-table/demo-schema.json
+++ b/mes-universal-table/demo-schema.json
@@ -26,7 +26,7 @@
           { "label": "B", "value": "B" }
         ]
       },
-      { "field_id": "api_value", "field_name": "API Value", "field_type": "api", "endpoint": "/api/value", "bind_field": "name" },
+      { "field_id": "api_value", "field_name": "API Value", "field_type": "lookup", "endpoint": "/api/value", "bind_field": "name" },
       {
         "field_id": "total",
         "field_name": "Total",


### PR DESCRIPTION
- Changed 'api' field_type to 'lookup' in demo-schema.json to prevent potential runtime errors from an unhandled type. This is the likely fix for general button unresponsiveness.
- Refactored column removal logic to use field_id instead of array index (removeColumnByFieldId), making it more robust.
- Updated the remove column button in headers to use the new logic.